### PR TITLE
chore: disable pnpm auto-install peers in app hosting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+auto-install-peers=false
 node-linker=hoisted
 link-workspace-packages=true

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -7,7 +7,3 @@ env:
     value: firebase_app_hosting
     availability:
       - BUILD
-  - variable: PNPM_CONFIG_AUTO_INSTALL_PEERS
-    value: "false"
-    availability:
-      - BUILD


### PR DESCRIPTION
## Summary
- disable pnpm auto-install-peers during App Hosting builds to avoid install error