### PR TITLE
Add application loading progress and UI copy polish

### DIFF
--- a/apps/web/src/lib/os/create-route-application.tsx
+++ b/apps/web/src/lib/os/create-route-application.tsx
@@ -19,6 +19,7 @@ import { useWindowManager } from "@acme/ui/os/window-manager";
 import { Link } from "@tanstack/react-router";
 import { Maximize, Minimize, Minus, X } from "lucide-react";
 import React, { useEffect } from "react";
+import { useSystem } from "@/routes/-components/system/system-provider";
 import type { FileRoutesByTo } from "../../routeTree.gen";
 
 type RouteApplicationDefinition = ApplicationDefinition & {
@@ -30,6 +31,7 @@ export function createApplicationRoute(toPath: keyof FileRoutesByTo) {
 
   return ({
     component: ApplicationComponent,
+    fallback: FallbackComponent,
     launcher: LauncherComponent,
     ...applicationFactoryDefinition
   }: RouteApplicationDefinition) => {
@@ -87,6 +89,26 @@ export function createApplicationRoute(toPath: keyof FileRoutesByTo) {
             <ApplicationComponent />
           </Window>
         );
+      },
+      fallback: () => {
+        const { insertLoadingApplication, removeLoadingApplication } =
+          useSystem();
+        const { application } = Application.useApplication();
+
+        const onLoadStart = React.useEffectEvent(() => {
+          insertLoadingApplication(application);
+        });
+
+        const onLoadEnd = React.useEffectEvent(() => {
+          removeLoadingApplication(application);
+        });
+
+        React.useEffect(() => {
+          onLoadStart();
+          return onLoadEnd;
+        }, []);
+
+        if (FallbackComponent) return <FallbackComponent />;
       },
     });
 

--- a/apps/web/src/routes/-components/applications/application-progress-bar.tsx
+++ b/apps/web/src/routes/-components/applications/application-progress-bar.tsx
@@ -1,0 +1,88 @@
+import { Progress } from "@acme/ui/components/progress";
+import React from "react";
+import { useSystem } from "../system/system-provider";
+
+type ApplicationProgressProps = Omit<
+  React.ComponentProps<typeof Progress>,
+  "value"
+>;
+
+export function ApplicationProgressBar({ ...props }: ApplicationProgressProps) {
+  const { loadingApplications } = useSystem();
+  const [progress, setProgress] = React.useState(0);
+  const intervalRef = React.useRef<number | null>(null);
+  const completionTimeoutRef = React.useRef<number | null>(null);
+  const previousCountRef = React.useRef(0);
+
+  const clearTimers = React.useCallback(() => {
+    if (intervalRef.current) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (completionTimeoutRef.current) {
+      window.clearTimeout(completionTimeoutRef.current);
+      completionTimeoutRef.current = null;
+    }
+  }, []);
+
+  const startProgress = React.useCallback(() => {
+    clearTimers();
+    intervalRef.current = window.setInterval(() => {
+      setProgress((prev) => {
+        const ceiling = 92;
+        const rate = prev < 50 ? 0.18 : 0.06;
+        const next = prev + (ceiling - prev) * rate;
+        return Math.min(next, ceiling);
+      });
+    }, 120);
+  }, [clearTimers]);
+
+  const resetProgress = React.useCallback(() => {
+    clearTimers();
+    setProgress(0);
+  }, [clearTimers]);
+
+  /**
+   * @privateRemarks
+   * We set the progress to as close to 100 as possible to make it look like it's done.
+   * The progress bar will be hidden after a short delay when setting the progress to 100.
+   * If another application starts within this range, it will be reset to 0.
+   */
+  const finishProgress = React.useCallback(() => {
+    clearTimers();
+    setProgress(99.99999);
+    completionTimeoutRef.current = window.setTimeout(() => {
+      setProgress(100);
+    }, 360);
+  }, [clearTimers]);
+
+  React.useEffect(() => {
+    const previousCount = previousCountRef.current;
+    const currentCount = loadingApplications.length;
+
+    if (currentCount > 0) {
+      if (currentCount > previousCount) resetProgress();
+      startProgress();
+    } else if (previousCount > 0) {
+      finishProgress();
+    }
+
+    previousCountRef.current = currentCount;
+  }, [
+    loadingApplications.length,
+    startProgress,
+    resetProgress,
+    finishProgress,
+  ]);
+
+  // If unmounted, clear any pending timers.
+  React.useEffect(() => clearTimers, [clearTimers]);
+
+  const shouldShowProgress =
+    loadingApplications.length > 0 || (progress > 0 && progress < 100);
+
+  // Hide the progress bar as soon as it's complete.
+  if (!shouldShowProgress) return null;
+
+  return <Progress value={progress} {...props} />;
+}

--- a/apps/web/src/routes/-components/applications/application-sidebar.tsx
+++ b/apps/web/src/routes/-components/applications/application-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarSeparator,
+  SidebarTrigger,
   useSidebar,
 } from "@acme/ui/components/sidebar";
 import { cn } from "@acme/ui/lib/utils";
@@ -78,7 +79,7 @@ function ApplicationSidebar({
         <SidebarGroup>
           {runningApplications.length ? (
             <>
-              <SidebarGroupLabel>Running apps</SidebarGroupLabel>
+              <SidebarGroupLabel>Running Applications</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
                   {runningApplications.map((application) => {
@@ -123,4 +124,15 @@ function ApplicationSidebar({
   );
 }
 
-export { ApplicationSidebar };
+type ApplicationSidebarTriggerProps = Omit<
+  React.ComponentProps<typeof SidebarTrigger>,
+  "label"
+>;
+
+function ApplicationSidebarTrigger(props: ApplicationSidebarTriggerProps) {
+  return (
+    <SidebarTrigger variant="ghost" label="Manage applications" {...props} />
+  );
+}
+
+export { ApplicationSidebar, ApplicationSidebarTrigger };

--- a/apps/web/src/routes/-components/bsod/bsod-launcher.tsx
+++ b/apps/web/src/routes/-components/bsod/bsod-launcher.tsx
@@ -7,11 +7,13 @@ import {
 import { Link } from "@tanstack/react-router";
 import { Link2Off } from "lucide-react";
 
+const bsodRoute = `/${encodeURIComponent("you're-absolutely-right!")}`;
+
 export function BSODLauncher() {
   return (
     <Launcher asChild>
       {/* @ts-ignore: This is done on purpose to trigger a 404 easter egg. */}
-      <Link to="/definitely-not-here" rel="nofollow">
+      <Link to={bsodRoute} rel="nofollow">
         <LauncherContent>
           <LauncherIcon className="bg-background/90 backdrop-blur-xs">
             <Link2Off className="h-7 w-7 text-foreground/90" />

--- a/apps/web/src/routes/-components/bsod/bsod.tsx
+++ b/apps/web/src/routes/-components/bsod/bsod.tsx
@@ -46,17 +46,12 @@ export function BSODScreen() {
         <div>
           <Frown className="size-12" />
         </div>
-        <div className="text-lg leading-relaxed">
-          Your PC ran into a problem and needs to restart.
-        </div>
-        <div className="font-medium text-[#f1f6ff] [text-shadow:0_1px_0_rgba(0,0,0,0.35)]">
-          <code>ERROR: AI_SLOP_DEPLOYED_TO_PROD</code>
-        </div>
-        <div className="text-[#f1f6ff] text-sm [text-shadow:0_1px_0_rgba(0,0,0,0.35)]">
+        <div className="space-y-2 text-[#f1f6ff] leading-relaxed [text-shadow:0_1px_0_rgba(0,0,0,0.35)]">
+          <p>Your PC ran into a problem and needs to restart.</p>
           <p>If you call a support person, give them this info:</p>
-          <p>
-            <code>STOP_CODE: HALLUCINATED_ROUTE</code>
-          </p>
+          <code>
+            ERROR: <b>AI_SLOP_DEPLOYED_TO_PROD</b>
+          </code>
         </div>
         <Button
           onClick={shutdown}

--- a/apps/web/src/routes/-components/desktop/desktop.tsx
+++ b/apps/web/src/routes/-components/desktop/desktop.tsx
@@ -1,4 +1,3 @@
-import { SidebarTrigger } from "@acme/ui/components/sidebar";
 import { ThemeMenu } from "@acme/ui/components/theme";
 import { cn } from "@acme/ui/lib/utils";
 import { Taskbar, TaskbarDivider, TaskbarSection } from "@acme/ui/os/taskbar";
@@ -16,6 +15,8 @@ import {
   ResumeApplication,
   ResumeLauncher,
 } from "../../(applications)/resume/-components/application";
+import { ApplicationProgressBar } from "../applications/application-progress-bar";
+import { ApplicationSidebarTrigger } from "../applications/application-sidebar";
 import { BSODLauncher } from "../bsod/bsod-launcher";
 import { TaskbarClock } from "../taskbar/taskbar-clock";
 import { TaskbarGitHub } from "../taskbar/taskbar-github";
@@ -33,6 +34,8 @@ export function Desktop({ className, children, ...props }: DesktopProps) {
       {...props}
     >
       <DesktopWallpaper className="absolute h-full w-full" />
+
+      <ApplicationProgressBar className="absolute top-0 left-0 z-progress" />
 
       <WindowBoundary className="pointer-events-none min-h-0 w-full flex-1 **:pointer-events-auto">
         <WindowSnap>
@@ -65,7 +68,7 @@ export function Desktop({ className, children, ...props }: DesktopProps) {
         <TaskbarDivider />
         <TaskbarSection className="h-full" align="end">
           <ThemeMenu variant="ghost" />
-          <SidebarTrigger variant="ghost" />
+          <ApplicationSidebarTrigger variant="ghost" />
           <TaskbarClock className="hidden px-2 py-1 text-xs md:flex" />
         </TaskbarSection>
       </Taskbar>

--- a/apps/web/src/routes/-components/root/root-providers.tsx
+++ b/apps/web/src/routes/-components/root/root-providers.tsx
@@ -1,5 +1,6 @@
 import { SidebarProvider } from "@acme/ui/components/sidebar";
 import { TooltipProvider } from "@acme/ui/components/tooltip";
+import { DEFAULT_TOOLTIP_DELAY_DURATION } from "@acme/ui/lib/constants";
 import { ApplicationManagerProvider } from "@acme/ui/os/application-manager";
 import { WindowManagerProvider } from "@acme/ui/os/window-manager";
 import * as React from "react";
@@ -20,7 +21,7 @@ export function RootProviders({ children }: RootLayoutProps) {
           onOpenChange={setSidebarOpen}
           className="flex flex-col"
         >
-          <TooltipProvider delayDuration={0}>
+          <TooltipProvider delayDuration={DEFAULT_TOOLTIP_DELAY_DURATION}>
             <ClientRootProviders>{children}</ClientRootProviders>
           </TooltipProvider>
         </SidebarProvider>

--- a/apps/web/src/routes/-components/taskbar/taskbar-clock.tsx
+++ b/apps/web/src/routes/-components/taskbar/taskbar-clock.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@acme/ui/components/dropdown-menu";
 import {
@@ -82,6 +83,9 @@ export function TaskbarClock({ className, ...props }: ClockProps) {
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuLabel className="select-none text-foreground/55 text-xs">
+            Formats
+          </DropdownMenuLabel>
           <DropdownMenuItem onClick={() => setFormat("24")}>
             24-hour
           </DropdownMenuItem>

--- a/apps/web/src/routes/-components/taskbar/taskbar-start.tsx
+++ b/apps/web/src/routes/-components/taskbar/taskbar-start.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@acme/ui/components/dropdown-menu";
 import {
@@ -46,13 +47,16 @@ export function TaskbarStart({ className, ...props }: TaskbarLogoProps) {
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuLabel className="select-none text-foreground/55 text-xs">
+            Start Menu
+          </DropdownMenuLabel>
           <DropdownMenuItem onClick={quitApplications}>
-            Quit all applications
+            Quit applications
           </DropdownMenuItem>
           <DropdownMenuItem onClick={shutdown}>Shut down</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <TooltipContent>Start menu</TooltipContent>
+      <TooltipContent>Open start menu</TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6,6 +6,7 @@
   --z-formatting: 100;
   --z-taskbar: 10000;
   --z-power: 10100;
+  --z-progress: 10200;
 }
 
 @theme inline {
@@ -14,6 +15,7 @@
   --z-index-formatting: calc(var(--z-formatting));
   --z-index-taskbar: calc(var(--z-taskbar));
   --z-index-power: calc(var(--z-power));
+  --z-index-progress: calc(var(--z-progress));
 }
 
 @keyframes tv-on {

--- a/packages/ui/src/blocknote/editor.tsx
+++ b/packages/ui/src/blocknote/editor.tsx
@@ -42,6 +42,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../components/tooltip";
+import { DEFAULT_TOOLTIP_DELAY_DURATION } from "../lib/constants";
 
 const base = BlockNoteSchema.create();
 
@@ -119,7 +120,12 @@ export function BlockNoteEditor(props: BlockNoteEditorProps) {
         Tooltip: {
           Tooltip,
           TooltipContent,
-          TooltipProvider,
+          TooltipProvider: (props) => (
+            <TooltipProvider
+              {...props}
+              delayDuration={DEFAULT_TOOLTIP_DELAY_DURATION}
+            />
+          ),
           TooltipTrigger,
         },
       }}

--- a/packages/ui/src/components/progress.tsx
+++ b/packages/ui/src/components/progress.tsx
@@ -1,0 +1,29 @@
+import { Progress as ProgressPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "../lib/utils";
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "relative h-1 w-full overflow-hidden rounded-full bg-primary/20",
+        className,
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -17,12 +17,7 @@ import {
   SheetTitle,
 } from "./sheet";
 import { Skeleton } from "./skeleton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -133,25 +128,23 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
-        <div
-          data-slot="sidebar-wrapper"
-          style={
-            {
-              "--sidebar-width": SIDEBAR_WIDTH,
-              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-              ...style,
-            } as React.CSSProperties
-          }
-          className={cn(
-            "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
-            className,
-          )}
-          {...props}
-        >
-          {children}
-        </div>
-      </TooltipProvider>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
     </SidebarContext.Provider>
   );
 }
@@ -267,10 +260,15 @@ function Sidebar({
   );
 }
 
+type SidebarTriggerProps = React.ComponentProps<typeof Button> & {
+  label?: string;
+};
+
 function SidebarTrigger({
   onClick,
+  label = "Toggle sidebar",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: SidebarTriggerProps) {
   const { toggleSidebar } = useSidebar();
 
   return (
@@ -288,10 +286,10 @@ function SidebarTrigger({
           {...props}
         >
           <PanelRightIcon />
-          <span className="sr-only bg-background">Toggle Sidebar</span>
+          <span className="sr-only bg-background">{label}</span>
         </Button>
       </TooltipTrigger>
-      <TooltipContent>Toggle sidebar</TooltipContent>
+      <TooltipContent>{label}</TooltipContent>
     </Tooltip>
   );
 }
@@ -303,10 +301,10 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label="Toggle sidebar"
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title="Toggle sidebar"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/packages/ui/src/components/theme.tsx
+++ b/packages/ui/src/components/theme.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "./dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
@@ -114,13 +115,16 @@ export function ThemeMenu(props: ThemeToggleProps) {
             <Button variant="ghost" size="icon" {...props}>
               <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
               <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              <span className="sr-only bg-background">Toggle Theme</span>
+              <span className="sr-only bg-background">Toggle theme</span>
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent>Change theme</TooltipContent>
       </Tooltip>
       <DropdownMenuContent align="end">
+        <DropdownMenuLabel className="select-none text-foreground/55 text-xs">
+          Themes
+        </DropdownMenuLabel>
         <DropdownMenuItem onClick={() => setTheme("light")}>
           Light
         </DropdownMenuItem>

--- a/packages/ui/src/lib/constants.ts
+++ b/packages/ui/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TOOLTIP_DELAY_DURATION = 200;

--- a/packages/ui/src/os/window-actions.tsx
+++ b/packages/ui/src/os/window-actions.tsx
@@ -8,6 +8,8 @@ import { useApplication, useApplicationId } from "./application";
 import { useWindow } from "./window";
 import { useWindowManager } from "./window-manager";
 
+const ACTIONS_TOOLTIP_DELAY_DURATION = 150;
+
 const INPUT_TAGNAME = "INPUT";
 const INPUT_TEXTAREA = "TEXTAREA";
 const INPUT_SELECT = "SELECT";
@@ -106,7 +108,7 @@ function WindowHideButton({
   });
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={ACTIONS_TOOLTIP_DELAY_DURATION}>
       <TooltipTrigger asChild>
         <WindowAction
           ref={ref}
@@ -151,7 +153,7 @@ function WindowFullscreenButton({
   });
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={ACTIONS_TOOLTIP_DELAY_DURATION}>
       <TooltipTrigger asChild>
         <WindowAction
           ref={ref}
@@ -195,7 +197,7 @@ function WindowCloseButton({
   });
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={ACTIONS_TOOLTIP_DELAY_DURATION}>
       <TooltipTrigger asChild>
         <WindowAction
           ref={ref}


### PR DESCRIPTION
## Summary
- track loading applications and display a global launch progress bar in the desktop
- add shared progress/tooltip defaults and align sidebar/theme/taskbar labels
- refresh BSOD copy and start/clock menu structure

## Testing
- not run