### PR TITLE
Fix DOOM input release and taskbar sizing

### DIFF
--- a/apps/web/public/dwasm/index.html
+++ b/apps/web/public/dwasm/index.html
@@ -16,7 +16,6 @@
         -webkit-user-select: none;
         user-select: none;
         -webkit-touch-callout: none;
-        touch-action: none;
       }
 
       #screen {
@@ -34,6 +33,7 @@
         height: 100%;
         outline: none;
         background: #000;
+        touch-action: none;
       }
 
       /* Status badge (hidden once runtime is ready) */
@@ -556,6 +556,7 @@
             controls.querySelectorAll("button[data-key]"),
           );
           const activeCounts = new Map();
+          const activeKeyInfo = new Map();
           const pointerKeys = new Map();
           const joystickElements = Array.from(
             controls.querySelectorAll("[data-joystick]"),
@@ -608,6 +609,7 @@
             const count = activeCounts.get(info.code) || 0;
             if (count === 0) sendKey("keydown", info);
             activeCounts.set(info.code, count + 1);
+            activeKeyInfo.set(info.code, info);
           }
 
           function release(info) {
@@ -615,6 +617,7 @@
             if (count <= 1) {
               activeCounts.delete(info.code);
               sendKey("keyup", info);
+              activeKeyInfo.delete(info.code);
             } else {
               activeCounts.set(info.code, count - 1);
             }
@@ -788,11 +791,29 @@
             });
           }
 
+          function releaseAllButtons() {
+            activeKeyInfo.forEach((info) => {
+              sendKey("keyup", info);
+            });
+            activeCounts.clear();
+            activeKeyInfo.clear();
+            pointerKeys.clear();
+            buttons.forEach((button) => {
+              button.classList.remove("is-pressed");
+            });
+          }
+
+          function releaseAllInputs() {
+            releaseAllButtons();
+            releaseAllJoysticks();
+          }
+
           buttons.forEach((button) => {
             button.addEventListener("pointerdown", handlePointerDown);
             button.addEventListener("pointerup", handlePointerUp);
             button.addEventListener("pointercancel", handlePointerCancel);
             button.addEventListener("pointerleave", handlePointerUp);
+            button.addEventListener("lostpointercapture", handlePointerCancel);
           });
 
           joystickElements.forEach((joystick) => {
@@ -819,9 +840,11 @@
             event.preventDefault();
           });
 
-          window.addEventListener("blur", releaseAllJoysticks);
+          window.addEventListener("blur", releaseAllInputs);
+          window.addEventListener("pagehide", releaseAllInputs);
+          window.addEventListener("pointercancel", releaseAllInputs);
           document.addEventListener("visibilitychange", () => {
-            if (document.hidden) releaseAllJoysticks();
+            if (document.hidden) releaseAllInputs();
           });
         }
 

--- a/apps/web/src/routes/-components/desktop/desktop.tsx
+++ b/apps/web/src/routes/-components/desktop/desktop.tsx
@@ -48,14 +48,14 @@ export function Desktop({ className, children, ...props }: DesktopProps) {
       {/* Nested Routes are rendered here. For now, these will only be programmatic launchers, no HTML will be rendered. */}
       {children}
 
-      <DesktopGrid className="absolute bottom-9 h-[calc(100dvh-2.25rem)] min-h-0 flex-1 p-2">
+      <DesktopGrid className="absolute max-h-full min-h-0 flex-1 p-2">
         <AboutLauncher />
         <ResumeLauncher />
         <DoomLauncher />
         <BSODLauncher />
       </DesktopGrid>
 
-      <Taskbar className="z-taskbar shrink-0">
+      <Taskbar className="z-taskbar max-w-dvw shrink-0">
         <TaskbarSection className="h-full" align="start">
           <TaskbarStart />
           <TaskbarGitHub />

--- a/apps/web/src/routes/-components/taskbar/taskbar-start.tsx
+++ b/apps/web/src/routes/-components/taskbar/taskbar-start.tsx
@@ -28,9 +28,13 @@ export function TaskbarStart({ className, ...props }: TaskbarLogoProps) {
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" asChild>
-              <TaskbarItem variant="icon" onClick={quitApplications}>
+              <TaskbarItem
+                className="text-accent hover:text-accent-foreground"
+                variant="icon"
+                onClick={quitApplications}
+              >
                 <svg
-                  className={cn("h-6 w-6", className)}
+                  className={cn("size-5", className)}
                   role="img"
                   viewBox="0 0 433 289"
                   fill="currentColor"

--- a/apps/web/src/routes/-components/taskbar/taskbar-tab-strip.tsx
+++ b/apps/web/src/routes/-components/taskbar/taskbar-tab-strip.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@acme/ui/lib/utils";
 import { useApplicationManager } from "@acme/ui/os/application-manager";
 import {
   TabStrip,
@@ -12,11 +13,14 @@ import { useWindowManager } from "@acme/ui/os/window-manager";
 import React from "react";
 
 type ApplicationTabStripProps = Omit<
-  typeof TabStrip,
+  React.ComponentProps<typeof TabStrip>,
   "value" | "onValueChange"
 >;
 
-export function TaskbarTabStrip(props: ApplicationTabStripProps) {
+export function TaskbarTabStrip({
+  className,
+  ...props
+}: ApplicationTabStripProps) {
   const { runningApplications, close } = useApplicationManager();
   const { activateWindow, getTopWindow, hideWindow } = useWindowManager();
 
@@ -37,7 +41,11 @@ export function TaskbarTabStrip(props: ApplicationTabStripProps) {
   }, [activeWindow]);
 
   return (
-    <TabStrip value={activeWindow?.id ?? ""} {...props} className="border-none">
+    <TabStrip
+      className={cn("w-full min-w-0 flex-1 border-none", className)}
+      value={activeWindow?.id ?? ""}
+      {...props}
+    >
       <TabStripRail>
         <TabStripList className="border-none p-0">
           {runningApplications.map((application) => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -180,7 +180,7 @@ function RouteShellComponent({ children }: { children: React.ReactNode }) {
         <HeadContent />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       </head>
-      <body className="bg-background">
+      <body className="relative bg-background">
         <RootProviders>
           {children}
           <ApplicationSidebar />

--- a/packages/ui/src/blocknote/editor.tsx
+++ b/packages/ui/src/blocknote/editor.tsx
@@ -42,7 +42,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../components/tooltip";
-import { DEFAULT_TOOLTIP_DELAY_DURATION } from "../lib/constants";
 
 const base = BlockNoteSchema.create();
 
@@ -120,12 +119,7 @@ export function BlockNoteEditor(props: BlockNoteEditorProps) {
         Tooltip: {
           Tooltip,
           TooltipContent,
-          TooltipProvider: (props) => (
-            <TooltipProvider
-              {...props}
-              delayDuration={DEFAULT_TOOLTIP_DELAY_DURATION}
-            />
-          ),
+          TooltipProvider,
           TooltipTrigger,
         },
       }}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,10 +1,10 @@
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import type * as React from "react";
-
+import { DEFAULT_TOOLTIP_DELAY_DURATION } from "../lib/constants";
 import { cn } from "../lib/utils";
 
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = DEFAULT_TOOLTIP_DELAY_DURATION,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (

--- a/packages/ui/src/os/tab-strip.tsx
+++ b/packages/ui/src/os/tab-strip.tsx
@@ -6,7 +6,9 @@ import { useIsMobile } from "../hooks/use-mobile";
 import { cn } from "../lib/utils";
 
 function TabStrip({ className, ...props }: React.ComponentProps<typeof Tabs>) {
-  return <Tabs className={cn("w-full", className)} {...props} />;
+  return (
+    <Tabs className={cn("w-full min-w-0 max-w-full", className)} {...props} />
+  );
 }
 
 function TabStripRail({
@@ -72,9 +74,9 @@ function TabStripTabTrigger({
       ref={tabRef}
       data-slot="tabstrip-tab-trigger"
       className={cn(
-        "h-7 max-w-48 justify-start rounded-md border border-transparent px-2 pr-6 text-foreground/70",
+        "h-7 max-w-48 justify-start rounded-md border px-2 pr-6 text-foreground/70",
         "hover:bg-muted/60 hover:text-foreground",
-        "data-[state=active]:border-border/60 data-[state=active]:bg-background/90 data-[state=active]:text-foreground",
+        "data-[state=active]:border-border/60! data-[state=active]:bg-background/90 data-[state=active]:text-foreground",
         className,
       )}
       value={value}


### PR DESCRIPTION
## Summary
- release stuck mobile inputs in the DOOM iframe and limit touch capture scope
- tighten taskbar sizing so tabs/start icon stay within the bar
- make tooltip delay defaults consistent across BlockNote and core UI

## Testing
- not run