### PR TITLE
Refactor sidebar layout wrapper

### DIFF
--- a/apps/storybook/src/os/taskbar.stories.tsx
+++ b/apps/storybook/src/os/taskbar.stories.tsx
@@ -1,4 +1,4 @@
-import { SidebarProvider } from "@acme/ui/components/sidebar";
+import { SidebarProvider, SidebarWrapper } from "@acme/ui/components/sidebar";
 import { ApplicationManagerProvider } from "@acme/ui/os/application-manager";
 import { Taskbar, TaskbarItem, TaskbarSection } from "@acme/ui/os/taskbar";
 import { WindowBoundary } from "@acme/ui/os/window-boundary";
@@ -54,66 +54,66 @@ export const Default: Story = {
     }, [sidebarOpen]);
 
     return (
-      <SidebarProvider
-        open={sidebarOpen}
-        onOpenChange={setSidebarOpen}
-        className="flex flex-col bg-transparent"
-        style={{ "--sidebar-width": "22rem" } as React.CSSProperties}
-      >
-        <WindowManagerProvider>
-          <ApplicationManagerProvider>
-            <div className="flex h-full min-h-dvh w-full flex-col bg-[#e9e2d2]">
-              <WindowBoundary className="h-full w-full flex-1">
-                <WindowSnap>
-                  {/* Application layer. */}
-                  <MailApplication.Component />
-                  <NotesApplication.Component />
-                  <InsightsApplication.Component />
+      <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
+        <SidebarWrapper
+          className="flex flex-col bg-transparent"
+          style={{ "--sidebar-width": "22rem" } as React.CSSProperties}
+        >
+          <WindowManagerProvider>
+            <ApplicationManagerProvider>
+              <div className="flex h-full min-h-dvh w-full flex-col bg-[#e9e2d2]">
+                <WindowBoundary className="h-full w-full flex-1">
+                  <WindowSnap>
+                    {/* Application layer. */}
+                    <MailApplication.Component />
+                    <NotesApplication.Component />
+                    <InsightsApplication.Component />
 
-                  {/* Desktop layer. */}
-                  <div ref={panelRef}>
-                    <ApplicationManagerSidebar />
-                  </div>
-                  <div className="m-4">
-                    <MailApplicationLauncher />
-                    <NotesApplicationLauncher />
-                    <InsightsApplicationLauncher />
-                  </div>
-                </WindowSnap>
-              </WindowBoundary>
+                    {/* Desktop layer. */}
+                    <div ref={panelRef}>
+                      <ApplicationManagerSidebar />
+                    </div>
+                    <div className="m-4">
+                      <MailApplicationLauncher />
+                      <NotesApplicationLauncher />
+                      <InsightsApplicationLauncher />
+                    </div>
+                  </WindowSnap>
+                </WindowBoundary>
 
-              <Taskbar className="mx-4 my-2 rounded-full border border-black/10 text-slate-900 shadow-[0_18px_40px_rgba(15,23,42,0.25)]">
-                <TaskbarSection
-                  align="start"
-                  className="gap-1 text-slate-700 text-sm"
-                  grow
-                >
-                  <TaskbarItem
-                    variant="icon"
-                    className="text-slate-700 hover:bg-black/5"
+                <Taskbar className="mx-4 my-2 rounded-full border border-black/10 text-slate-900 shadow-[0_18px_40px_rgba(15,23,42,0.25)]">
+                  <TaskbarSection
+                    align="start"
+                    className="gap-1 text-slate-700 text-sm"
+                    grow
                   >
-                    <span className="h-7 bg-slate-900 text-white">OS</span>
-                  </TaskbarItem>
-                  <ProductMenu />
-                  <MoreMenu />
-                </TaskbarSection>
+                    <TaskbarItem
+                      variant="icon"
+                      className="text-slate-700 hover:bg-black/5"
+                    >
+                      <span className="h-7 bg-slate-900 text-white">OS</span>
+                    </TaskbarItem>
+                    <ProductMenu />
+                    <MoreMenu />
+                  </TaskbarSection>
 
-                <TaskbarSection>
-                  <TaskbarItem
-                    variant="icon"
-                    aria-label="Window manager"
-                    active={sidebarOpen}
-                    className="text-slate-700 hover:bg-black/5"
-                    onClick={() => setSidebarOpen((prev) => !prev)}
-                    ref={toggleRef}
-                  >
-                    <PanelRightOpen className="size-4" />
-                  </TaskbarItem>
-                </TaskbarSection>
-              </Taskbar>
-            </div>
-          </ApplicationManagerProvider>
-        </WindowManagerProvider>
+                  <TaskbarSection>
+                    <TaskbarItem
+                      variant="icon"
+                      aria-label="Window manager"
+                      active={sidebarOpen}
+                      className="text-slate-700 hover:bg-black/5"
+                      onClick={() => setSidebarOpen((prev) => !prev)}
+                      ref={toggleRef}
+                    >
+                      <PanelRightOpen className="size-4" />
+                    </TaskbarItem>
+                  </TaskbarSection>
+                </Taskbar>
+              </div>
+            </ApplicationManagerProvider>
+          </WindowManagerProvider>
+        </SidebarWrapper>
       </SidebarProvider>
     );
   },

--- a/apps/web/src/routes/(applications)/about/-components/about.tsx
+++ b/apps/web/src/routes/(applications)/about/-components/about.tsx
@@ -9,8 +9,6 @@ import { GITHUB_URL, LINKEDIN_URL } from "@/lib/socials/constants";
 
 export function About() {
   const { theme } = useTheme();
-
-  // Creates a new editor instance.
   const editor = useBlockNoteEditor({
     initialContent: [
       {

--- a/apps/web/src/routes/-components/root/root-layout.tsx
+++ b/apps/web/src/routes/-components/root/root-layout.tsx
@@ -1,10 +1,13 @@
+import { SidebarWrapper } from "@acme/ui/components/sidebar";
 import { cn } from "@acme/ui/lib/utils";
+import type * as React from "react";
 import { useNotFound } from "@/hooks/use-not-found";
+import { ApplicationSidebar } from "../applications/application-sidebar";
 import { Desktop } from "../desktop/desktop";
 import { PowerButton, PowerScreen } from "../power/power";
 import { useSystem } from "../system/system-provider";
 
-type SystemLayoutProps = React.ComponentProps<"div">;
+type SystemLayoutProps = React.ComponentProps<typeof SidebarWrapper>;
 
 export function RootLayout({
   children,
@@ -17,28 +20,34 @@ export function RootLayout({
   const isOn = power === "on";
 
   return (
-    <div className={cn("relative flex flex-1", className)} {...props}>
-      <div
-        className={cn("flex flex-1", {
-          "animate-power-off": isOff,
-          "animate-power-on": isOn,
-        })}
-      >
-        {isNotFound ? children : <Desktop>{children}</Desktop>}
-      </div>
-      {isOff && (
-        <PowerScreen
-          className={cn(
-            "absolute inset-0 top-0 left-0 z-power h-full w-full",
-            "animate-screen-blackout opacity-0",
-          )}
+    <SidebarWrapper
+      className={cn("relative flex flex-col", className)}
+      {...props}
+    >
+      <div className={"flex flex-1"}>
+        <div
+          className={cn("flex flex-1", {
+            "animate-power-off": isOff,
+            "animate-power-on": isOn,
+          })}
         >
-          <PowerButton
-            className="rounded-full bg-transparent!"
-            onClick={boot}
-          />
-        </PowerScreen>
-      )}
-    </div>
+          {isNotFound ? children : <Desktop>{children}</Desktop>}
+        </div>
+        {isOff && (
+          <PowerScreen
+            className={cn(
+              "absolute inset-0 top-0 left-0 z-power h-full w-full",
+              "animate-screen-blackout opacity-0",
+            )}
+          >
+            <PowerButton
+              className="rounded-full bg-transparent!"
+              onClick={boot}
+            />
+          </PowerScreen>
+        )}
+      </div>
+      <ApplicationSidebar />
+    </SidebarWrapper>
   );
 }

--- a/apps/web/src/routes/-components/root/root-providers.tsx
+++ b/apps/web/src/routes/-components/root/root-providers.tsx
@@ -16,11 +16,7 @@ export function RootProviders({ children }: RootLayoutProps) {
   return (
     <ApplicationManagerProvider>
       <WindowManagerProvider>
-        <SidebarProvider
-          open={sidebarOpen}
-          onOpenChange={setSidebarOpen}
-          className="flex flex-col"
-        >
+        <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
           <TooltipProvider delayDuration={DEFAULT_TOOLTIP_DELAY_DURATION}>
             <ClientRootProviders>{children}</ClientRootProviders>
           </TooltipProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,7 +18,6 @@ import {
   SITE_TITLE,
 } from "@/lib/socials/constants";
 import appCss from "../styles.css?url";
-import { ApplicationSidebar } from "./-components/applications/application-sidebar";
 import { BSODScreen } from "./-components/bsod/bsod";
 import { RootLayout } from "./-components/root/root-layout";
 import { RootProviders } from "./-components/root/root-providers";
@@ -181,10 +180,7 @@ function RouteShellComponent({ children }: { children: React.ReactNode }) {
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       </head>
       <body className="relative bg-background">
-        <RootProviders>
-          {children}
-          <ApplicationSidebar />
-        </RootProviders>
+        <RootProviders>{children}</RootProviders>
         <TanStackDevtools
           config={{
             position: "bottom-right",

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -46,19 +46,18 @@ function useSidebar() {
   return context;
 }
 
+type SidebarProviderProps = React.PropsWithChildren<{
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
+
 function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
-  className,
-  style,
   children,
-  ...props
-}: React.ComponentProps<"div"> & {
-  defaultOpen?: boolean;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-}) {
+}: SidebarProviderProps) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
 
@@ -126,23 +125,7 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <div
-        data-slot="sidebar-wrapper"
-        style={
-          {
-            "--sidebar-width": SIDEBAR_WIDTH,
-            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-            ...style,
-          } as React.CSSProperties
-        }
-        className={cn(
-          "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </div>
+      {children}
     </SidebarContext.Provider>
   );
 }
@@ -378,6 +361,33 @@ function SidebarSeparator({
       className={cn("mx-2 w-auto bg-sidebar-border", className)}
       {...props}
     />
+  );
+}
+
+function SidebarWrapper({
+  className,
+  children,
+  style,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-wrapper"
+      style={
+        {
+          "--sidebar-width": SIDEBAR_WIDTH,
+          "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+          ...style,
+        } as React.CSSProperties
+      }
+      className={cn(
+        "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
@@ -713,6 +723,7 @@ function SidebarMenuSubButton({
 
 export {
   Sidebar,
+  SidebarWrapper,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,

--- a/packages/ui/src/components/theme.tsx
+++ b/packages/ui/src/components/theme.tsx
@@ -6,7 +6,6 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { cn } from "../lib/utils";
 import { Button } from "./button";
 import {
   DropdownMenu,
@@ -139,26 +138,20 @@ export function ThemeMenu(props: ThemeToggleProps) {
   );
 }
 
-export function LightThemeOnly({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+export function LightThemeOnly({ children }: React.PropsWithChildren) {
   const { theme } = useTheme();
 
   if (theme !== "light") return null;
 
-  return <div className={cn("hidden", className)} {...props} />;
+  return children;
 }
 
-export function DarkThemeOnly({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+export function DarkThemeOnly({ children }: React.PropsWithChildren) {
   const { theme } = useTheme();
 
   if (theme !== "dark") return null;
 
-  return <div className={cn("hidden", className)} {...props} />;
+  return children;
 }
 
 function getSystemTheme() {


### PR DESCRIPTION
## Summary
- move sidebar layout wrapper concerns into a dedicated SidebarWrapper component
- restructure RootLayout and RootProviders to use the wrapper at the app root
- align Storybook taskbar demo with the new wrapper structure

## Testing
- not run